### PR TITLE
improve figure img styles; fixes #479

### DIFF
--- a/web/wp-content/themes/lfevents/src/assets/scss/modules/_content.scss
+++ b/web/wp-content/themes/lfevents/src/assets/scss/modules/_content.scss
@@ -193,18 +193,18 @@ figure {
 
 // apply to figure
 .figure-container img {
-	width: 100%;
-	// height: 100%;
-	object-fit: cover;
-	position: absolute;
-	z-index: 1;
-	// added below to stop flexbox messing with the height on load.
-	display: block;
-	top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    height: auto;
-    width: 100%;
+  max-width: none;
+  min-width: 100%;
+  max-height: none;
+  min-height: 100%;
+  object-fit: cover !important;
+  position: absolute;
+  z-index: 1;
+  // added below to stop flexbox messing with the height on load.
+  display: block;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
 // apply to content inside

--- a/web/wp-content/themes/lfevents/src/assets/scss/modules/_content.scss
+++ b/web/wp-content/themes/lfevents/src/assets/scss/modules/_content.scss
@@ -197,7 +197,7 @@ figure {
   min-width: 100%;
   max-height: none;
   min-height: 100%;
-  object-fit: cover !important;
+  object-fit: cover;
   position: absolute;
   z-index: 1;
   // added below to stop flexbox messing with the height on load.


### PR DESCRIPTION
This PR addresses #479 by nixing all explicit widths/heights on `figure img` and using `max-[width,height]=auto` and `min-[width,height]=100%`. 

This will need to be thoroughly tested. @cjyabraham, can you help me look for all the other places this might effect. Should only be in the page headers, but the styles target any `figure` element. 