### PR TITLE
Check event date is set correctly, otherwise output TBA

### DIFF
--- a/web/wp-config.php
+++ b/web/wp-config.php
@@ -168,6 +168,16 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ):
 		define( 'DISALLOW_FILE_MODS', true );
 	endif;
 
+	// if environment is Lando run in debug.
+	if ( 'lando' === $_ENV['PANTHEON_ENVIRONMENT'] ) :
+		define( 'WP_DEBUG', true );
+		define( 'WP_DEBUG_DISPLAY', true ); // false to go to log.
+		define( 'WP_DEBUG_LOG', __DIR__ . '/wp-content/debug.log' ); // Moves log file to writable location.
+		define( 'SCRIPT_DEBUG', true );
+		define( 'WP_DISABLE_FATAL_ERROR_HANDLER', true ); // stops admin email sent.
+
+	endif;
+
 endif;
 
 /*
@@ -247,4 +257,3 @@ if ( 0 === strpos( $_SERVER['REQUEST_URI'], '/events/' ) ) {
 		exit();
 	}
 }
-

--- a/web/wp-content/mu-plugins/custom/lfevents/public/class-lfevents-public.php
+++ b/web/wp-content/mu-plugins/custom/lfevents/public/class-lfevents-public.php
@@ -105,6 +105,10 @@ class LFEvents_Public {
 	public function redirects() {
 		global $post;
 
+		if ( ! is_object( $post ) ) {
+			return;
+		}
+
 		if ( in_array( $post->post_type, lfe_get_post_types() ) && $post->post_parent ) {
 			$args = array(
 				'post_parent' => $post->ID,

--- a/web/wp-content/plugins/pricing-block/src/init.php
+++ b/web/wp-content/plugins/pricing-block/src/init.php
@@ -97,24 +97,19 @@ function block_callback( $att ) {
 	$dates = $att['dates'];
 	$left_labels = $att['leftLabels'];
 	$prices = $att['prices'];
-	$expire_text = $att['expireText'];
-	if ( ! $expire_text ) {
-		$expire_text = 'Expired';
-	}
-	$color1 = $att['color1'];
-	$color2 = $att['color2'];
-	$color3 = $att['color3'];
-	$color4 = $att['color4'];
+	$expire_text = $att['expireText'] ?? 'Expired';
+	$color1 = $att['color1'] ?? '';
+	$color2 = $att['color2'] ?? '';
+	$color3 = $att['color3'] ?? '';
+	$color4 = $att['color4'] ?? '';
 	$color_text = $att['colorText'];
-	$tz = $att['timeZone'];
-	if ( ! $tz ) {
-		$tz = '-0700';
-	}
+	$tz = $att['timeZone'] ?? '-0700';
 	$yesterday = new DateTime( 'now', new DateTimeZone( $tz ) );
 	$yesterday->sub( new DateInterval( 'P1D' ) );
 
 	$column = 0;
 	$row = 0;
+	$html = '';
 
 	if ( ! $top_labels || ! $dates || ! $left_labels || ! $prices ) {
 		return '';

--- a/web/wp-content/themes/lfevents/functions.php
+++ b/web/wp-content/themes/lfevents/functions.php
@@ -57,5 +57,5 @@ require_once 'library/gutenberg.php';
 /** If your site requires protocol relative url's for theme assets, uncomment the line below */
 // require_once( 'library/class-foundationpress-protocol-relative-theme-assets.php' ); //.
 
-/** Add LFEvents funcitons */
+/** Add LFEvents functions */
 require_once 'library/lfe-functions.php';

--- a/web/wp-content/themes/lfevents/home.php
+++ b/web/wp-content/themes/lfevents/home.php
@@ -107,7 +107,7 @@ get_template_part( 'template-parts/global-nav' );
 								}
 
 								$date_start = get_post_meta( $post->ID, 'lfes_date_start', true );
-								if ( 'TBA' === strtoupper( $date_start ) ) {
+								if ( ! check_string_is_date( $date_start ) ) {
 									$date_range = 'TBA';
 								} else {
 									$dt_date_start = new DateTime( $date_start );

--- a/web/wp-content/themes/lfevents/library/lfe-functions.php
+++ b/web/wp-content/themes/lfevents/library/lfe-functions.php
@@ -798,7 +798,7 @@ function lfe_passed_event_banner( $parent_id ) {
 		}
 	}
 	$term = wp_get_post_terms( $parent_id, 'lfevent-category', array( 'fields' => 'all' ) );
-	if ( $term[0] ) {
+	if ( ! empty( $term ) && $term[0] ) {
 		echo 'View the upcoming <a style="color:inherit;text-decoration:underline;" href="https://events.linuxfoundation.org/about/calendar/?_sft_lfevent-category=' . urlencode( $term[0]->slug ) . '"> ' . esc_html( $term[0]->name ) . '.</a>';
 	} else {
 		echo 'View upcoming <a style="color:inherit;text-decoration:underline;" href="https://events.linuxfoundation.org/">Linux Foundation events.</a>';

--- a/web/wp-content/themes/lfevents/library/lfe-functions.php
+++ b/web/wp-content/themes/lfevents/library/lfe-functions.php
@@ -393,6 +393,17 @@ function lfe_insert_favicon() {
 }
 
 /**
+ * Checks a string is a date.
+ *
+ * @param string $date suspected date.
+ * @param string $format datetime format, default Y/m/d.
+ */
+function check_string_is_date( $date, $format = 'Y/m/d' ) {
+	$d = DateTime::createFromFormat( $format, $date );
+	return $d && $d->format( $format ) === $date;
+}
+
+/**
  * Makes the date pretty.  Adapted from https://9seeds.com/pretty-php-date-ranges/.
  *
  * @param datetime $start_date The start date.
@@ -468,12 +479,16 @@ add_filter( 'excerpt_more', 'new_excerpt_more' );
 function lfe_insert_structured_data() {
 	global $post;
 
+	if ( ! is_object( $post ) ) {
+		return;
+	}
+
 	if ( $post->post_parent || 'page' != $post->post_type ) {
 		return;
 	}
 
 	$date_start = get_post_meta( $post->ID, 'lfes_date_start', true );
-	if ( 'TBA' !== strtoupper( $date_start ) ) {
+	if ( check_string_is_date( $date_start ) ) {
 		$dt_date_start = new DateTime( $date_start );
 		$dt_date_end   = new DateTime( get_post_meta( $post->ID, 'lfes_date_end', true ) );
 	}
@@ -494,7 +509,7 @@ function lfe_insert_structured_data() {
 	$out .= '"@context": "http://schema.org/",';
 	$out .= '"@type": "Event",';
 	$out .= '"name": "' . esc_html( $post->post_title ) . '",';
-	if ( 'TBA' !== strtoupper( $date_start ) ) {
+	if ( check_string_is_date( $date_start ) ) {
 		$out .= '"startDate": "' . $dt_date_start->format( 'Y-m-d' ) . '",';
 		$out .= '"endDate": "' . $dt_date_end->format( 'Y-m-d' ) . '",';
 	}

--- a/web/wp-content/themes/lfevents/search-filter/4480.php
+++ b/web/wp-content/themes/lfevents/search-filter/4480.php
@@ -33,7 +33,8 @@ if ( $query->have_posts() ) {
 		}
 
 		$date_start = get_post_meta( $post->ID, 'lfes_date_start', true );
-		if ( 'TBA' === strtoupper( $date_start ) ) {
+		// if date is set incorrectly, then return TBA.
+		if ( ! check_string_is_date( $date_start ) ) {
 			$date_range = 'TBA';
 		} else {
 			$dt_date_start = new DateTime( $date_start );

--- a/web/wp-content/themes/lfevents/search-filter/results.php
+++ b/web/wp-content/themes/lfevents/search-filter/results.php
@@ -47,7 +47,7 @@ if ( $query->have_posts() ) {
 	while ( $query->have_posts() ) {
 		$query->the_post();
 		$date_start = get_post_meta( $post->ID, 'lfes_date_start', true );
-		if ( 'TBA' === strtoupper( $date_start ) ) {
+		if ( ! check_string_is_date( $date_start ) ) {
 			$date_range = 'TBA';
 		} else {
 			$dt_date_start = new DateTime( $date_start );
@@ -77,10 +77,11 @@ if ( $query->have_posts() ) {
 
 
 		if ( $is_upcoming_events ) {
-			if ( 'TBA' === strtoupper( $date_start ) ) {
+
+			if ( ! check_string_is_date( $date_start ) ) {
 				if ( 'TBA' !== $y ) {
 					$y = 'TBA';
-					echo '<h2 class="cell event-calendar-year">TBA</h2>';
+					echo '<h2 class="cell event-calendar-year">To Be Announced</h2>';
 				}
 			} else {
 				if ( ( 0 == $y ) || ( $y < (int) $dt_date_start->format( 'Y' ) ) ) {

--- a/web/wp-content/themes/lfevents/search-filter/results.php
+++ b/web/wp-content/themes/lfevents/search-filter/results.php
@@ -26,7 +26,7 @@ echo '<div class="grid-x grid-margin-x">';
 if ( $query->have_posts() ) {
 	if ( 138 == $query->query['search_filter_id'] || 42 == $query->query['search_filter_id'] ) {
 		$is_upcoming_events = true;
-		$full_count = $wpdb->get_var( "SELECT count(*) FROM wp_posts INNER JOIN wp_postmeta as pm1 ON ( wp_posts.ID = pm1.post_id ) INNER JOIN wp_postmeta pm2 ON ( wp_posts.ID = pm2.post_id ) INNER JOIN wp_postmeta pm3 ON ( wp_posts.ID = pm3.post_id ) WHERE ( pm1.meta_key = 'lfes_event_has_passed' ) AND (pm1.meta_value != 1) AND ( pm2.meta_key = 'lfes_hide_from_listings' ) AND (pm2.meta_value != 'hide') AND wp_posts.post_type = 'page' AND (wp_posts.post_status = 'publish' OR wp_posts.post_status = 'pending') AND wp_posts.post_parent = 0 AND (pm3.meta_value > 1) AND ( pm3.meta_key = 'lfes_date_start' )" );
+		$full_count = $wpdb->get_var( "SELECT count(*) FROM wp_posts INNER JOIN wp_postmeta as pm1 ON ( wp_posts.ID = pm1.post_id ) INNER JOIN wp_postmeta pm2 ON ( wp_posts.ID = pm2.post_id ) INNER JOIN wp_postmeta pm3 ON ( wp_posts.ID = pm3.post_id ) WHERE ( pm1.meta_key = 'lfes_event_has_passed' ) AND (pm1.meta_value != 1) AND ( pm2.meta_key = 'lfes_hide_from_listings' ) AND (pm2.meta_value != 'hide') AND wp_posts.post_type = 'page' AND (wp_posts.post_status = 'publish' OR wp_posts.post_status = 'pending') AND wp_posts.post_parent = 0 AND (pm3.meta_value <> '') AND ( pm3.meta_key = 'lfes_date_start' )" );
 	} else {
 		$is_upcoming_events = false;
 		$post_types = lfe_get_post_types();
@@ -81,7 +81,7 @@ if ( $query->have_posts() ) {
 			if ( ! check_string_is_date( $date_start ) ) {
 				if ( 'TBA' !== $y ) {
 					$y = 'TBA';
-					echo '<h2 class="cell event-calendar-year">To Be Announced</h2>';
+					echo '<h2 class="cell event-calendar-year">TBA</h2>';
 				}
 			} else {
 				if ( ( 0 == $y ) || ( $y < (int) $dt_date_start->format( 'Y' ) ) ) {

--- a/web/wp-content/themes/lfevents/singular.php
+++ b/web/wp-content/themes/lfevents/singular.php
@@ -21,6 +21,7 @@ get_header();
 
 $splash_page = get_post_meta( get_the_ID(), 'lfes_splash_page', true );
 $hide_header = get_post_meta( get_the_ID(), 'lfes_hide_header', true );
+$event_has_passed = false;
 
 if ( ! $splash_page ) {
 	// menu background color.


### PR DESCRIPTION
- Adds debug output to lando / local environment
- Fixes #595 
- Fixes some other PHP errors

WRT #595: 
1. To see the error, set an event date for something that is not a recognised date or "TBA". In this instance, the editor used "TBD" by mistake, and this caused fatal error
2. The code now checks the input, if the date is wrong or a word is written, it will class the event as TBA, rather than requiring TBA to be written.
