### PR TITLE
Speed up nested pages

### DIFF
--- a/web/wp-content/mu-plugins/custom/lfevents/admin/class-lfevents-admin.php
+++ b/web/wp-content/mu-plugins/custom/lfevents/admin/class-lfevents-admin.php
@@ -1320,11 +1320,8 @@ class LFEvents_Admin {
 	 */
 	public function limit_nested_pages_listing( $query ) {
 		$lfe_faster_np_checkbox = get_option( 'lfe-faster-np-checkbox' );
-		if ( ! $lfe_faster_np_checkbox ) {
-			return;
-		}
 
-		if ( is_admin() && isset( $_SERVER['REQUEST_URI'] ) && ( '/wp/wp-admin/admin.php?page=nestedpages' === $_SERVER['REQUEST_URI'] ) && isset( $query->query['orderby'] ) ) {
+		if ( $lfe_faster_np_checkbox && is_admin() && isset( $_SERVER['REQUEST_URI'] ) && ( '/wp/wp-admin/admin.php?page=nestedpages' === $_SERVER['REQUEST_URI'] ) && isset( $query->query['orderby'] ) ) {
 			$query->set(
 				'meta_query',
 				array(

--- a/web/wp-content/mu-plugins/custom/lfevents/admin/class-lfevents-admin.php
+++ b/web/wp-content/mu-plugins/custom/lfevents/admin/class-lfevents-admin.php
@@ -1314,6 +1314,26 @@ class LFEvents_Admin {
 	}
 
 	/**
+	 * Limits the number of pages listed in the Nested Pages admin views
+	 *
+	 * @param object $query Existing query.
+	 */
+	public function limit_nested_pages_listing( $query ) {
+
+		if ( is_admin() && isset( $_SERVER['REQUEST_URI'] ) && ( '/wp/wp-admin/admin.php?page=nestedpages' === $_SERVER['REQUEST_URI'] ) && isset( $query->query['orderby'] ) ) {
+			$query->set(
+				'date_query',
+				array(
+					array(
+						'column' => 'post_modified_gmt',
+						'after' => '5 months ago',
+					),
+				),
+			);
+		}
+	}
+
+	/**
 	 * If the Event has a external url set then this sets the noindex meta to true and vice versa.
 	 *
 	 * @param int $post_id The post id.

--- a/web/wp-content/mu-plugins/custom/lfevents/admin/class-lfevents-admin.php
+++ b/web/wp-content/mu-plugins/custom/lfevents/admin/class-lfevents-admin.php
@@ -1322,13 +1322,18 @@ class LFEvents_Admin {
 
 		if ( is_admin() && isset( $_SERVER['REQUEST_URI'] ) && ( '/wp/wp-admin/admin.php?page=nestedpages' === $_SERVER['REQUEST_URI'] ) && isset( $query->query['orderby'] ) ) {
 			$query->set(
-				'date_query',
+				'meta_query',
 				array(
+					'relation' => 'OR',
 					array(
-						'column' => 'post_modified_gmt',
-						'after' => '5 months ago',
+						'key' => '_nested_pages_status',
+						'compare' => 'NOT EXISTS',
 					),
-				),
+					array(
+						'key' => '_nested_pages_status',
+						'value' => 'show',
+					),
+				)
 			);
 		}
 	}

--- a/web/wp-content/mu-plugins/custom/lfevents/admin/class-lfevents-admin.php
+++ b/web/wp-content/mu-plugins/custom/lfevents/admin/class-lfevents-admin.php
@@ -1319,6 +1319,10 @@ class LFEvents_Admin {
 	 * @param object $query Existing query.
 	 */
 	public function limit_nested_pages_listing( $query ) {
+		$lfe_faster_np_checkbox = get_option( 'lfe-faster-np-checkbox' );
+		if ( ! $lfe_faster_np_checkbox ) {
+			return;
+		}
 
 		if ( is_admin() && isset( $_SERVER['REQUEST_URI'] ) && ( '/wp/wp-admin/admin.php?page=nestedpages' === $_SERVER['REQUEST_URI'] ) && isset( $query->query['orderby'] ) ) {
 			$query->set(

--- a/web/wp-content/mu-plugins/custom/lfevents/includes/class-lfevents.php
+++ b/web/wp-content/mu-plugins/custom/lfevents/includes/class-lfevents.php
@@ -166,6 +166,7 @@ class LFEvents {
 		$this->loader->add_action( 'pre_get_posts', $plugin_admin, 'event_list_filter' );
 		$this->loader->add_action( 'save_post', $plugin_admin, 'synchronize_noindex_meta' );
 		$this->loader->add_action( 'save_post', $plugin_admin, 'reset_cache_check' );
+		$this->loader->add_action( 'pre_get_posts', $plugin_admin, 'limit_nested_pages_listing' );
 
 		// schedule KCD sync on lfeventsci.
 		if ( 'lfeventsci' === $_ENV['PANTHEON_SITE_NAME'] ) {

--- a/web/wp-content/themes/lfevents/functions.php
+++ b/web/wp-content/themes/lfevents/functions.php
@@ -59,6 +59,7 @@ require_once 'library/gutenberg.php';
 
 /** Add LFEvents functions */
 require_once 'library/lfe-functions.php';
+require_once 'library/lfe-options.php';
 
 require_once 'library/shortcode-travel-fund-request-form.php';
 require_once 'library/shortcode-visa-request-form.php';

--- a/web/wp-content/themes/lfevents/library/lfe-options.php
+++ b/web/wp-content/themes/lfevents/library/lfe-options.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * LFEvents options page
+ *
+ * @package WordPress
+ * @subpackage Twenty_Nineteen
+ * @since 1.0.0
+ */
+
+/**
+ * Settings page.
+ */
+function lfe_settings_page() {
+	add_settings_section( 'lfe_options_section', '', null, 'lfe_options' );
+	add_settings_field( 'lfe-faster-np-checkbox', 'Faster Nested Pages', 'lfe_faster_np_checkbox_display', 'lfe_options', 'lfe_options_section' );
+	register_setting( 'lfe_options_section', 'lfe-faster-np-checkbox' );
+}
+
+/**
+ * Checkbox callback.
+ */
+function lfe_faster_np_checkbox_display() {
+	?>
+		<!-- Here we are comparing stored value with 1. Stored value is 1 if user checks the checkbox otherwise empty string. -->
+		<input type='checkbox' name='lfe-faster-np-checkbox' value='1' <?php checked( 1, get_option( 'lfe-faster-np-checkbox' ), true ); ?> />
+		<p class='description'>
+		Check this box to speed up the Nested Pages tool.  When checked, the hidden Events will not be accessible.
+		</p>
+	<?php
+}
+
+add_action( 'admin_init', 'lfe_settings_page' );
+
+/**
+ * Options page callback.
+ */
+function lfe_options_page() {
+	?>
+	  <div class='wrap'>
+		 <h1>LF Events Options</h1>
+ 
+		 <form method='post' action='options.php'>
+			<?php
+			   settings_fields( 'lfe_options_section' );
+
+			   do_settings_sections( 'lfe_options' );
+
+			   submit_button();
+			?>
+		 </form>
+	  </div>
+	<?php
+}
+
+/**
+ * Add item to settings menu.
+ */
+function lfe_menu_item() {
+	add_submenu_page( 'options-general.php', 'LFEvents Options', 'LFEvents Options', 'manage_options', 'lfe_options', 'lfe_options_page' );
+}
+
+add_action( 'admin_menu', 'lfe_menu_item' );


### PR DESCRIPTION
This PR limits the main admin nested-pages view of the Events to only show pages that have been edited in the last 5 months.  This significantly speeds up the use of the interface and makes it scalable long-term.

Note: in order to see a nested page in the view, the parent page must have been edited in the last 5 months, otherwise neither are seen, no matter how recently the nested page was edited.

[See the nested pages view here](https://pr-669-lfeventsci.pantheonsite.io/wp/wp-admin/admin.php?page=nestedpages).

On deploy
- [ ] Write up how it works in the Admin instructions