### PR TITLE
Pricing Table improvements and Osano experiments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ behat-local.yml
 wraith/configs/capture.yaml
 wraith/shots
 web/wp-content/themes/twentynineteen/node_modules
+*.code-workspace
 
 # :::::::::::::::::::::: cut ::::::::::::::::::::::
 

--- a/web/wp-content/themes/lfevents/library/enqueue-scripts.php
+++ b/web/wp-content/themes/lfevents/library/enqueue-scripts.php
@@ -94,7 +94,7 @@ if ( ! function_exists( 'foundationpress_scripts' ) ) :
 		}
 
 		// Cookie script.
-		wp_enqueue_script( 'osano', 'https://cmp.osano.com/16A0DbT9yDNIaQkvZ/3b49aaa9-15ab-4d47-a8fb-96cc25b5543c/osano.js', array(), '1', true );
+		wp_enqueue_script( 'osano', 'https://cmp.osano.com/16A0DbT9yDNIaQkvZ/3b49aaa9-15ab-4d47-a8fb-96cc25b5543c/osano.js', array(), '1', false );
 
 	}
 	add_action( 'wp_enqueue_scripts', 'foundationpress_scripts' );

--- a/web/wp-content/themes/lfevents/library/lfe-functions.php
+++ b/web/wp-content/themes/lfevents/library/lfe-functions.php
@@ -100,7 +100,6 @@ function lfe_get_related_events( $parent_id ) {
 	wp_reset_postdata(); // Restore original Post Data.
 
 	return $related_events;
-
 }
 
 /**
@@ -294,7 +293,6 @@ function lfe_get_sponsors( $parent_id ) {
 		}
 	}
 	wp_reset_postdata(); // Restore original Post Data.
-
 }
 
 /**
@@ -347,7 +345,6 @@ EOD;
 		echo $analytics_code; //phpcs:ignore
 	}
 }
-
 
 /**
  * Inserts Event-specific favicon if set, otherwise falls back to site favicon.
@@ -610,29 +607,39 @@ function change_to_preconnect_resource_hints( $hints, $relation_type ) {
 }
 add_filter( 'wp_resource_hints', 'change_to_preconnect_resource_hints', 10, 2 );
 
-add_filter( 'emoji_svg_url', '__return_false' );
-
-
-/* Will only run on front end of site */
-if ( ! is_admin() ) {
-	/**
-	 * Make all JS defer onload (in conjunction with moving jQuery to footer).
-	 *
-	 * @param string $url the URL.
-	 */
-	function defer_parsing_of_js( $url ) {
-		if ( false === strpos( $url, '.js' ) ) {
-			return $url;
-		}
-		if ( strpos( $url, 'jquery-3.5.1.min.js' ) && ! is_front_page() ) {
-			return $url;
-		}
-		return str_replace( ' src', ' defer src', $url );
+/**
+ * Make all JS defer onload apart from files specified.
+ *
+ * Use strpos to exclude specific files.
+ *
+ * @param string $url the URL.
+ */
+function lf_defer_parsing_of_js( $url ) {
+	// Stop if admin.
+	if ( is_admin() ) {
+		return $url;
 	}
-	add_filter( 'script_loader_tag', 'defer_parsing_of_js', 10 );
-}
+	// Stop if not JS.
+	if ( false === strpos( $url, '.js' ) ) {
+		return $url;
+	}
+	// List of scripts that should not be deferred.
+	$do_not_defer_scripts = array( 'jquery-3.5.1.min.js', 'osano.js' );
 
+	if ( count( $do_not_defer_scripts ) > 0 ) {
+		foreach ( $do_not_defer_scripts as $script ) {
+			if ( strpos( $url, $script ) ) {
+				return $url;
+			}
+		}
+	}
+	return str_replace( ' src', ' defer src', $url );
+}
+add_filter( 'script_loader_tag', 'lf_defer_parsing_of_js', 10, 3 );
+
+add_filter( 'emoji_svg_url', '__return_false' );
 add_filter( 'the_seo_framework_image_generation_params', 'my_tsf_custom_image_generation_args', 10, 3 );
+
 /**
  * Adjusts image generation parameters for snackables.  It will get the snackable from the parent page.
  *
@@ -743,7 +750,6 @@ foreach ( $regex_json_path_patterns as $regex_json_path_pattern ) {
 		break;
 	}
 }
-
 
 /**
  * Returns a banner saying the event has passed for past events.

--- a/web/wp-content/themes/lfevents/src/assets/scss/blocks/_pricing-grid.scss
+++ b/web/wp-content/themes/lfevents/src/assets/scss/blocks/_pricing-grid.scss
@@ -24,7 +24,7 @@
     display: flex;
     position: relative;
 
-    >* {
+    > * {
       flex-grow: 1;
     }
 
@@ -54,7 +54,7 @@
     @include breakpoint(large) {
       font-weight: bold;
       font-size: rem-calc(10);
-      white-space: nowrap;
+      // white-space: nowrap;
     }
 
     @include breakpoint(xlarge) {
@@ -78,8 +78,6 @@
       margin-bottom: 1rem;
     }
 
-
-
     .expired-label {
       display: block;
       font-weight: normal;
@@ -98,12 +96,11 @@
   }
 
   @include breakpoint(large) {
-
     .attendee-type:not(:first-child) .price-window {
       display: none;
     }
 
-    .attendee-type>:first-child {
+    .attendee-type > :first-child {
       min-width: 12rem;
     }
 
@@ -123,7 +120,6 @@
 
   // overrides for the LFAsia
   .lfasiallcci & {
-
     @include breakpoint(large) {
       padding-top: 7rem;
 
@@ -143,12 +139,13 @@
 }
 
 .attendee-type {
+  max-width: 100%;
   margin-bottom: $global-margin/2;
 
   @include breakpoint(large) {
     display: flex;
 
-    >* {
+    > * {
       width: 12rem;
       margin: 0 $global-margin/4;
 
@@ -159,7 +156,7 @@
   }
 
   @include breakpoint(xlarge) {
-    >* {
+    > * {
       width: 14rem;
     }
   }

--- a/web/wp-content/themes/lfevents/src/assets/scss/blocks/_pricing-grid.scss
+++ b/web/wp-content/themes/lfevents/src/assets/scss/blocks/_pricing-grid.scss
@@ -1,3 +1,5 @@
+$price-cell: 5.25rem;
+
 .pricing-grid {
   width: auto;
   margin-top: 0;
@@ -11,9 +13,9 @@
     align-items: center;
     padding-left: 10px;
     padding-right: 10px;
-    // account for the price window header.
-    padding-top: 5.25rem;
     max-width: 100%;
+    // account for the price window header.
+    padding-top: calc(#{$price-cell} + 1.5rem);
   }
 
   .price-cell {
@@ -44,6 +46,9 @@
   .price-window--name {
     margin: 0;
     font-weight: bold;
+    @media (min-width: 1024px) and (max-width: 1200px) {
+      font-size: 1rem;
+    }
   }
 
   .price-window--date-range {
@@ -110,21 +115,25 @@
       right: 0;
       bottom: calc(100% + #{$global-margin/2});
       left: 0;
-      height: 4.25rem;
+      height: $price-cell;
       padding: 0.75rem;
       border-radius: 12px 12px 0 0;
       opacity: 0.75;
       text-align: center;
+      display: flex;
+      align-items: center;
+      align-content: center;
+      justify-content: center;
     }
   }
 
-  // overrides for the LFAsia
+  // overrides for the LFAsia.
   .lfasiallcci & {
     @include breakpoint(large) {
-      padding-top: 7rem;
+      padding-top: calc(#{$price-cell} + 1.5rem + 2rem);
 
       .price-window {
-        height: 7rem;
+        height: calc(#{$price-cell} + 1.75rem);
       }
 
       .price-window--name {


### PR DESCRIPTION

- Updating gitignore to ignore VS Code .code-workspace
- Make pricing grid respect container, #727 
- Moving Osano from Footer to Header, #728
- Removing defer from Osano as per install instructions #728

I copied the defer script from the CNCF site as the one we were using was only geared up to work with one exception file. The [Osano instructions say to not defer the osano script](https://docs.osano.com/installing-osano-on-wordpress).
In the old defer script we had this line:

`if ( strpos( $url, 'jquery-3.5.1.min.js' ) && ! is_front_page()`

I struggled to remember why or when the `! is_front_page()` was added to this script. Did we have issues with deferring jQuery? I looked through git history but I couldn't find why this was added. Anyway, its been removed in this new version, so we should thoroughly test.

The Osano enqueue was instructing it to load in the footer, so I switched this to the header. The wp_head() loads before the function inserted scripts. All other scripts should be deferred, so with Osano now not being deferred, it should be able to catch everything if it wasn't already.
