### PR TITLE
Override default cache headers to protect against DDOS

### DIFF
--- a/web/wp-content/mu-plugins/custom/lfevents/includes/class-lfevents.php
+++ b/web/wp-content/mu-plugins/custom/lfevents/includes/class-lfevents.php
@@ -217,6 +217,7 @@ class LFEvents {
 		$this->loader->add_filter( 'tiny_mce_plugins', $plugin_public, 'disable_emojicons_tinymce' );
 		$this->loader->add_action( 'pre_ping', $plugin_public, 'disable_pingback' );
 		$this->loader->add_filter( 'wp_resource_hints', $plugin_public, 'dns_prefetch_to_preconnect', 0, 2 );
+		$this->loader->add_action( 'send_headers', $plugin_public, 'add_header_cache', 15 );
 	}
 
 	/**

--- a/web/wp-content/mu-plugins/custom/lfevents/public/class-lfevents-public.php
+++ b/web/wp-content/mu-plugins/custom/lfevents/public/class-lfevents-public.php
@@ -384,6 +384,15 @@ class LFEvents_Public {
 	}
 
 	/**
+	 * Overrides the default cache headers.
+	 */
+	public function add_header_cache() {
+		if ( ! is_admin() && ! is_user_logged_in() ) {
+			header( 'Cache-Control: public, max-age=60, s-maxage=43200, stale-while-revalidate=86400, stale-if-error=604800' );
+		}
+	}
+
+	/**
 	 * Creates css into the head with the event gradient
 	 */
 	public function create_event_styles() {


### PR DESCRIPTION
As per [this issue](https://github.com/cncf/cncf.io/issues/729).

[Dev instance](https://pr-779-lfasiallcci.pantheonsite.io/)
[Dev instance lfasiallc](https://pr-779-lfeventsci.pantheonsite.io/)

Cache headers set when user is not logged in:
```
Cache-Control: public, max-age=60, s-maxage=43200, stale-while-revalidate=86400, stale-if-error=604800
```

Since Pantheon cache gets cleared on a page-by-page basis when a page is updated, I have pushed `s-maxage` to half a day.

We should observe how the cache hit rate changes after merge and make sure all assets are being properly cached which they don't seem to be on these dev instances. Also we should re-run pagespeed.