### PR TITLE
Add API to get events

### DIFF
--- a/web/wp-content/mu-plugins/custom/lfevents/includes/class-lfevents-api.php
+++ b/web/wp-content/mu-plugins/custom/lfevents/includes/class-lfevents-api.php
@@ -60,7 +60,7 @@ class LFEvents_API {
 			$status = 'upcoming';
 		}
 
-		$post_types = array_values( array_diff( lfe_get_post_types(), array( 'page' ) ) );
+		$post_types = lfe_get_post_types();
 
 		$meta_query = array(
 			'relation' => 'AND',
@@ -75,6 +75,11 @@ class LFEvents_API {
 					'value'   => 'hide',
 					'compare' => '!=',
 				),
+			),
+			array(
+				'key'     => 'lfes_date_start',
+				'value'   => '',
+				'compare' => '!=',
 			),
 		);
 

--- a/web/wp-content/mu-plugins/custom/lfevents/includes/class-lfevents-api.php
+++ b/web/wp-content/mu-plugins/custom/lfevents/includes/class-lfevents-api.php
@@ -117,10 +117,28 @@ class LFEvents_API {
 		);
 
 		if ( '' !== $search ) {
-			$args['s'] = $search;
+			$args['s']                   = $search;
+			$args['lfevents_title_only'] = true;
 		}
 
-		$query  = new WP_Query( $args );
+		$title_only_filter = function ( $search_sql, $wp_query ) {
+			global $wpdb;
+			if ( ! $wp_query->get( 'lfevents_title_only' ) ) {
+				return $search_sql;
+			}
+			$term = $wp_query->get( 's' );
+			if ( '' === $term ) {
+				return $search_sql;
+			}
+			$like = '%' . $wpdb->esc_like( $term ) . '%';
+			return $wpdb->prepare( " AND ({$wpdb->posts}.post_title LIKE %s) ", $like );
+		};
+		add_filter( 'posts_search', $title_only_filter, 10, 2 );
+
+		$query = new WP_Query( $args );
+
+		remove_filter( 'posts_search', $title_only_filter, 10 );
+
 		$events = array();
 
 		foreach ( $query->posts as $post ) {

--- a/web/wp-content/mu-plugins/custom/lfevents/includes/class-lfevents-api.php
+++ b/web/wp-content/mu-plugins/custom/lfevents/includes/class-lfevents-api.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * REST API for LFEvents.
+ *
+ * Exposes a public read-only endpoint that lists Events with a small
+ * set of fields useful for external consumers (calendars, widgets, etc.).
+ *
+ * @package    LFEvents
+ * @subpackage LFEvents/includes
+ */
+
+/**
+ * Registers and serves the LFEvents REST API.
+ */
+class LFEvents_API {
+
+	const NAMESPACE_V1 = 'lfevents/v1';
+
+	/**
+	 * Hook into rest_api_init.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			self::NAMESPACE_V1,
+			'/events',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'permission_callback' => '__return_true',
+				'callback'            => array( $this, 'get_events' ),
+				'args'                => array(
+					's'      => array(
+						'description'       => 'Free text search on event name.',
+						'type'              => 'string',
+						'required'          => false,
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'status' => array(
+						'description'       => 'Filter by event status.',
+						'type'              => 'string',
+						'required'          => false,
+						'default'           => 'upcoming',
+						'enum'              => array( 'upcoming', 'past', 'all' ),
+						'sanitize_callback' => 'sanitize_key',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Handle GET /lfevents/v1/events.
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 * @return WP_REST_Response
+	 */
+	public function get_events( WP_REST_Request $request ) {
+		$search = trim( (string) $request->get_param( 's' ) );
+		$status = $request->get_param( 'status' );
+		if ( ! in_array( $status, array( 'upcoming', 'past', 'all' ), true ) ) {
+			$status = 'upcoming';
+		}
+
+		$post_types = array_values( array_diff( lfe_get_post_types(), array( 'page' ) ) );
+
+		$meta_query = array(
+			'relation' => 'AND',
+			array(
+				'relation' => 'OR',
+				array(
+					'key'     => 'lfes_hide_from_listings',
+					'compare' => 'NOT EXISTS',
+				),
+				array(
+					'key'     => 'lfes_hide_from_listings',
+					'value'   => 'hide',
+					'compare' => '!=',
+				),
+			),
+		);
+
+		if ( 'upcoming' === $status ) {
+			$meta_query[] = array(
+				'relation' => 'OR',
+				array(
+					'key'     => 'lfes_event_has_passed',
+					'compare' => 'NOT EXISTS',
+				),
+				array(
+					'key'     => 'lfes_event_has_passed',
+					'value'   => '1',
+					'compare' => '!=',
+				),
+			);
+		} elseif ( 'past' === $status ) {
+			$meta_query[] = array(
+				'key'     => 'lfes_event_has_passed',
+				'value'   => '1',
+				'compare' => '=',
+			);
+		}
+
+		$args = array(
+			'post_type'      => $post_types,
+			'post_status'    => 'publish',
+			'post_parent'    => 0,
+			'posts_per_page' => -1,
+			'no_found_rows'  => true,
+			'meta_query'     => $meta_query, //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'orderby'        => 'meta_value',
+			'meta_key'       => 'lfes_date_start', //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			'order'          => 'past' === $status ? 'DESC' : 'ASC',
+		);
+
+		if ( '' !== $search ) {
+			$args['s'] = $search;
+		}
+
+		$query  = new WP_Query( $args );
+		$events = array();
+
+		foreach ( $query->posts as $post ) {
+			$events[] = $this->format_event( $post );
+		}
+
+		return new WP_REST_Response( $events, 200 );
+	}
+
+	/**
+	 * Convert a post into the JSON response shape.
+	 *
+	 * @param WP_Post $post The event post.
+	 * @return array
+	 */
+	private function format_event( WP_Post $post ) {
+		$post_id      = $post->ID;
+		$external_url = get_post_meta( $post_id, 'lfes_external_url', true );
+		$url          = $external_url ? $external_url : get_permalink( $post );
+
+		$country_name  = '';
+		$country_terms = get_the_terms( $post_id, 'lfevent-country' );
+		if ( is_array( $country_terms ) && ! empty( $country_terms ) ) {
+			$country_name = $country_terms[0]->name;
+		}
+
+		$virtual = get_post_meta( $post_id, 'lfes_virtual', true );
+
+		return array(
+			'id'                    => $post_id,
+			'name'                  => html_entity_decode( get_the_title( $post ), ENT_QUOTES, 'UTF-8' ),
+			'start_date'            => (string) get_post_meta( $post_id, 'lfes_date_start', true ),
+			'end_date'              => (string) get_post_meta( $post_id, 'lfes_date_end', true ),
+			'location'              => array(
+				'city'    => (string) get_post_meta( $post_id, 'lfes_city', true ),
+				'country' => (string) $country_name,
+				'virtual' => (bool) $virtual,
+			),
+			'url'                   => $url,
+			'menu_background_color' => (string) get_post_meta( $post_id, 'lfes_menu_color', true ),
+			'menu_gradient_color'   => (string) get_post_meta( $post_id, 'lfes_menu_color_2', true ),
+			'menu_dropdown_color'   => (string) get_post_meta( $post_id, 'lfes_menu_color_3', true ),
+		);
+	}
+}

--- a/web/wp-content/mu-plugins/custom/lfevents/includes/class-lfevents-api.php
+++ b/web/wp-content/mu-plugins/custom/lfevents/includes/class-lfevents-api.php
@@ -156,7 +156,7 @@ class LFEvents_API {
 	 */
 	private function format_event( WP_Post $post ) {
 		$post_id      = $post->ID;
-		$external_url = get_post_meta( $post_id, 'lfes_external_url', true );
+		$external_url = (string) get_post_meta( $post_id, 'lfes_external_url', true );
 		$url          = $external_url ? $external_url : get_permalink( $post );
 
 		$country_name  = '';
@@ -165,22 +165,68 @@ class LFEvents_API {
 			$country_name = $country_terms[0]->name;
 		}
 
-		$virtual = get_post_meta( $post_id, 'lfes_virtual', true );
+		$virtual            = get_post_meta( $post_id, 'lfes_virtual', true );
+		$white_logo_url     = $this->resolve_media_url( get_post_meta( $post_id, 'lfes_white_logo', true ) );
+		$black_logo_url     = $this->resolve_media_url( get_post_meta( $post_id, 'lfes_black_logo', true ) );
+		$featured_image_url = (string) get_the_post_thumbnail_url( $post_id, 'full' );
 
 		return array(
-			'id'                    => $post_id,
-			'name'                  => html_entity_decode( get_the_title( $post ), ENT_QUOTES, 'UTF-8' ),
-			'start_date'            => (string) get_post_meta( $post_id, 'lfes_date_start', true ),
-			'end_date'              => (string) get_post_meta( $post_id, 'lfes_date_end', true ),
-			'location'              => array(
+			'id'                   => $post_id,
+			'name'                 => html_entity_decode( get_the_title( $post ), ENT_QUOTES, 'UTF-8' ),
+			'description'          => (string) get_post_meta( $post_id, 'lfes_description', true ),
+			'date_start'           => (string) get_post_meta( $post_id, 'lfes_date_start', true ),
+			'date_end'             => (string) get_post_meta( $post_id, 'lfes_date_end', true ),
+			'external_url'         => $external_url,
+			'white_logo'           => $white_logo_url,
+			'black_logo'           => $black_logo_url,
+			'menu_color'           => (string) get_post_meta( $post_id, 'lfes_menu_color', true ),
+			'menu_color_2'         => (string) get_post_meta( $post_id, 'lfes_menu_color_2', true ),
+			'menu_color_3'         => (string) get_post_meta( $post_id, 'lfes_menu_color_3', true ),
+			'menu_text_color'      => (string) get_post_meta( $post_id, 'lfes_menu_text_color', true ),
+			'featured_image'       => $featured_image_url,
+			'start_date'           => (string) get_post_meta( $post_id, 'lfes_date_start', true ),
+			'end_date'             => (string) get_post_meta( $post_id, 'lfes_date_end', true ),
+			'location'             => array(
 				'city'    => (string) get_post_meta( $post_id, 'lfes_city', true ),
 				'country' => (string) $country_name,
+				'region'  => (string) get_post_meta( $post_id, 'lfes_region', true ),
 				'virtual' => (bool) $virtual,
 			),
-			'url'                   => $url,
-			'menu_background_color' => (string) get_post_meta( $post_id, 'lfes_menu_color', true ),
-			'menu_gradient_color'   => (string) get_post_meta( $post_id, 'lfes_menu_color_2', true ),
-			'menu_dropdown_color'   => (string) get_post_meta( $post_id, 'lfes_menu_color_3', true ),
+			'cfp_active'           => (bool) get_post_meta( $post_id, 'lfes_cfp_active', true ),
+			'cfp_date_start'       => (string) get_post_meta( $post_id, 'lfes_cfp_date_start', true ),
+			'cfp_date_end'         => (string) get_post_meta( $post_id, 'lfes_cfp_date_end', true ),
+			'cta_speak_url'        => (string) get_post_meta( $post_id, 'lfes_cta_speak_url', true ),
+			'cta_register_url'     => (string) get_post_meta( $post_id, 'lfes_cta_register_url', true ),
+			'cta_sponsor_url'      => (string) get_post_meta( $post_id, 'lfes_cta_sponsor_url', true ),
+			'cta_sponsor_date_end' => (string) get_post_meta( $post_id, 'lfes_cta_sponsor_date_end', true ),
+			'cta_schedule_url'     => (string) get_post_meta( $post_id, 'lfes_cta_schedule_url', true ),
+			'cta_videos_url'       => (string) get_post_meta( $post_id, 'lfes_cta_videos_url', true ),
+			'url'                  => $url,
 		);
+	}
+
+	/**
+	 * Resolve a media meta value to a URL.
+	 *
+	 * Supports attachment IDs and direct URLs.
+	 *
+	 * @param mixed $value Raw media meta value.
+	 * @return string
+	 */
+	private function resolve_media_url( $value ) {
+		if ( empty( $value ) ) {
+			return '';
+		}
+
+		if ( is_numeric( $value ) ) {
+			$attachment_url = wp_get_attachment_url( (int) $value );
+			return $attachment_url ? (string) $attachment_url : '';
+		}
+
+		if ( is_string( $value ) ) {
+			return $value;
+		}
+
+		return '';
 	}
 }

--- a/web/wp-content/mu-plugins/custom/lfevents/includes/class-lfevents-api.php
+++ b/web/wp-content/mu-plugins/custom/lfevents/includes/class-lfevents-api.php
@@ -188,8 +188,8 @@ class LFEvents_API {
 			'end_date'             => (string) get_post_meta( $post_id, 'lfes_date_end', true ),
 			'location'             => array(
 				'city'    => (string) get_post_meta( $post_id, 'lfes_city', true ),
-				'country' => (string) $country_name,
 				'region'  => (string) get_post_meta( $post_id, 'lfes_region', true ),
+				'country' => (string) $country_name,
 				'virtual' => (bool) $virtual,
 			),
 			'cfp_active'           => (bool) get_post_meta( $post_id, 'lfes_cfp_active', true ),

--- a/web/wp-content/mu-plugins/custom/lfevents/includes/class-lfevents.php
+++ b/web/wp-content/mu-plugins/custom/lfevents/includes/class-lfevents.php
@@ -120,6 +120,11 @@ class LFEvents {
 		 */
 		require_once plugin_dir_path( __DIR__ ) . 'public/class-lfevents-public.php';
 
+		/**
+		 * The class responsible for the public REST API.
+		 */
+		require_once plugin_dir_path( __DIR__ ) . 'includes/class-lfevents-api.php';
+
 		$this->loader = new LFEvents_Loader();
 	}
 
@@ -218,6 +223,9 @@ class LFEvents {
 		$this->loader->add_action( 'pre_ping', $plugin_public, 'disable_pingback' );
 		$this->loader->add_filter( 'wp_resource_hints', $plugin_public, 'dns_prefetch_to_preconnect', 0, 2 );
 		$this->loader->add_action( 'send_headers', $plugin_public, 'add_header_cache', 15 );
+
+		$plugin_api = new LFEvents_API();
+		$this->loader->add_action( 'rest_api_init', $plugin_api, 'register_routes' );
 	}
 
 	/**


### PR DESCRIPTION
See issue #1107 and #1114

# get_events API Quick Reference

## Endpoint
- `GET /wp-json/lfevents/v1/events`
- Public endpoint (no auth required)

## Query Params
- `status` (optional): `upcoming` (default), `past`, `all`
- `s` (optional): free-text search on event title only

## What You Get
- `200 OK` with a JSON array of events
- Full event object shape:

```json
{
  "id": 12345,
  "name": "Example Event",
  "description": "Event summary",
  "date_start": "2026-09-10",
  "date_end": "2026-09-12",
  "external_url": "https://events.example.org/event",
  "white_logo": "https://events.example.org/wp-content/uploads/white-logo.png",
  "black_logo": "https://events.example.org/wp-content/uploads/black-logo.png",
  "menu_color": "#0f172a",
  "menu_color_2": "#1e293b",
  "menu_color_3": "#334155",
  "menu_text_color": "#ffffff",
  "featured_image": "https://events.example.org/wp-content/uploads/hero.jpg",
  "start_date": "2026-09-10",
  "end_date": "2026-09-12",
  "location": {
    "city": "Chicago",
    "region": "IL",
    "country": "United States",
    "virtual": false
  },
  "cfp_active": true,
  "cfp_date_start": "2026-03-01",
  "cfp_date_end": "2026-04-15",
  "cta_speak_url": "https://events.example.org/cfp",
  "cta_register_url": "https://events.example.org/register",
  "cta_sponsor_url": "https://events.example.org/sponsor",
  "cta_sponsor_date_end": "2026-07-31",
  "cta_schedule_url": "https://events.example.org/schedule",
  "cta_videos_url": "https://events.example.org/videos",
  "url": "https://events.example.org/event"
}
```

## Behavior That Matters
- Hidden events are excluded.
- Events missing a start date are excluded.
- Sorting:
  - `upcoming` and `all`: earliest start date first
  - `past`: latest start date first
- `url` is `external_url` when set; otherwise it falls back to the event permalink.
- Results are not paginated (returns all matching events).
- Note that for events that exist on the https://www.lfopensource.cn/ site, this call will list the event but won't be able to get at the meta values.

## Example calls on dev site: 
- https://pr-1108-lfeventsci.pantheonsite.io/wp-json/lfevents/v1/events?status=upcoming
- https://pr-1108-lfeventsci.pantheonsite.io/wp-json/lfevents/v1/events?s=kubecon&status=all
- https://pr-1108-lfeventsci.pantheonsite.io/wp-json/lfevents/v1/events?s=kubecon&status=past


