### PR TITLE
Fix virtual event detection in sync_kcds()

### DIFF
--- a/web/wp-content/mu-plugins/custom/lfevents/admin/class-lfevents-admin.php
+++ b/web/wp-content/mu-plugins/custom/lfevents/admin/class-lfevents-admin.php
@@ -529,11 +529,10 @@ class LFEvents_Admin {
 				$dt_date_start = new DateTime( $event->start_date_iso );
 				$dt_date_end   = new DateTime( $event->end_date_iso );
 
-				$virtual = strpos( strtolower( $event->title ), 'virtual' ) + strpos( strtolower( $event->description_short ), 'virtual' );
-				if ( 0 < $virtual || ! $event->venue_city ) {
+				$virtual = str_contains( strtolower( $event->title ), 'virtual' )
+					|| str_contains( strtolower( $event->description_short ?? '' ), 'virtual' );
+				if ( ! $virtual && ! $event->venue_city ) {
 					$virtual = true;
-				} else {
-					$virtual = false;
 				}
 
 				$event_title = $event->title;


### PR DESCRIPTION
## What

`sync_kcds()` uses arithmetic on `strpos()` return values to detect whether an imported KCD event is virtual:

```php
$virtual = strpos( strtolower( $event->title ), 'virtual' )
         + strpos( strtolower( $event->description_short ), 'virtual' );
if ( 0 < $virtual || ! $event->venue_city ) {
```

`strpos()` returns the character **position** of the match, not a boolean. When "virtual" appears at position 0 (the first word of the title or description), `strpos()` returns `0`. `0 + false = 0`, and `0 < 0` is false — so the event gets classified as in-person even though "virtual" is right there in the title.

An event titled "Virtual KCD Amsterdam" with a venue city set would silently import as in-person and appear in geographic/location filters incorrectly.

## Fix

Replaced the arithmetic with `str_contains()` which returns a proper boolean, and added a `?? ''` fallback on `description_short` since it can be null on some events.

```php
$virtual = str_contains( strtolower( $event->title ), 'virtual' )
        || str_contains( strtolower( $event->description_short ?? '' ), 'virtual' );
if ( ! $virtual && ! $event->venue_city ) {
    $virtual = true;
}
```

Also removed the now-redundant `else { $virtual = false; }` branch since `$virtual` is already `false` at that point.

## Test plan

- [ ] Trigger `sync_kcds()` manually and confirm events with "Virtual" at the start of their title are imported with `lfes_community_virtual = true`
- [ ] Confirm in-person events with a venue city are still imported correctly
- [ ] Confirm events with no venue city are still marked virtual